### PR TITLE
🌿 fix: AssemblyAI http client supports polling

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,5 +1,6 @@
 # Specify files that shouldn't be modified by Fern
 
+src/main/java/com/assemblyai/api/AssemblyAI.java
 src/main/java/com/assemblyai/api/Transcriber.java
 src/main/java/com/assemblyai/api/RealtimeTranscriber.java
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The SDK exports a vanilla HTTP client, `AssemblyAI`. You can
 use this to call into each of our API endpoints and get typed
 responses back.
 
-```typescript
+```java
 import com.assemblyai.api.AssemblyAI;
 
 AssemblyAI aai = AssemblyAI.builder()
@@ -60,7 +60,7 @@ When the API returns a non-success status code (4xx or 5xx response),
 a subclass of [ApiError](src/main/java/com/assemblyai/api/core/ApiError.java)
 will be thrown:
 
-```ts
+```java
 import com.assemblyai.api.core.ApiError;
 
 try {

--- a/sample-app/src/main/java/sample/App.java
+++ b/sample-app/src/main/java/sample/App.java
@@ -58,6 +58,11 @@ public final class App {
 
         transcript = aai.transcript().create(CreateTranscriptParameters.builder()
                 .audioUrl("https://storage.googleapis.com/aai-docs-samples/nbc.mp3")
+                .build(), true);
+        System.out.println("Created and polled transcript " + transcript);
+
+        transcript = aai.transcript().create(CreateTranscriptParameters.builder()
+                .audioUrl("https://storage.googleapis.com/aai-docs-samples/nbc.mp3")
                 .build());
         System.out.println("Created transcript " + transcript);
 

--- a/src/main/java/com/assemblyai/api/AssemblyAI.java
+++ b/src/main/java/com/assemblyai/api/AssemblyAI.java
@@ -16,7 +16,7 @@ public class AssemblyAI {
 
     protected final Supplier<FilesClient> filesClient;
 
-    protected final Supplier<TranscriptClient> transcriptClient;
+    protected final Supplier<PollingTranscriptClient> transcriptClient;
 
     protected final Supplier<RealtimeClient> realtimeClient;
 
@@ -25,7 +25,8 @@ public class AssemblyAI {
     public AssemblyAI(ClientOptions clientOptions) {
         this.clientOptions = clientOptions;
         this.filesClient = Suppliers.memoize(() -> new FilesClient(clientOptions));
-        this.transcriptClient = Suppliers.memoize(() -> new TranscriptClient(clientOptions));
+        this.transcriptClient = Suppliers.memoize(() ->
+                        new PollingTranscriptClient(clientOptions, new Transcriber(this)));
         this.realtimeClient = Suppliers.memoize(() -> new RealtimeClient(clientOptions));
         this.lemurClient = Suppliers.memoize(() -> new LemurClient(clientOptions));
     }
@@ -34,7 +35,7 @@ public class AssemblyAI {
         return this.filesClient.get();
     }
 
-    public TranscriptClient transcript() {
+    public PollingTranscriptClient transcript() {
         return this.transcriptClient.get();
     }
 

--- a/src/main/java/com/assemblyai/api/PollingTranscriptClient.java
+++ b/src/main/java/com/assemblyai/api/PollingTranscriptClient.java
@@ -1,0 +1,24 @@
+package com.assemblyai.api;
+
+import com.assemblyai.api.core.ClientOptions;
+import com.assemblyai.api.resources.transcript.TranscriptClient;
+import com.assemblyai.api.resources.transcript.requests.CreateTranscriptParameters;
+import com.assemblyai.api.types.Transcript;
+
+public class PollingTranscriptClient extends TranscriptClient {
+
+    private final Transcriber transcriber;
+
+    public PollingTranscriptClient(ClientOptions clientOptions, Transcriber transcriber) {
+        super(clientOptions);
+        this.transcriber = transcriber;
+    }
+
+    /**
+     * Get the transcript resource. The transcript is ready when the &quot;status&quot; is &quot;completed&quot;.
+     */
+    public Transcript create(CreateTranscriptParameters request, boolean poll) {
+        return transcriber.transcribe(request.getAudioUrl(), request, poll);
+    }
+
+}

--- a/src/main/java/com/assemblyai/api/PollingTranscriptClient.java
+++ b/src/main/java/com/assemblyai/api/PollingTranscriptClient.java
@@ -15,7 +15,7 @@ public class PollingTranscriptClient extends TranscriptClient {
     }
 
     /**
-     * Get the transcript resource. The transcript is ready when the &quot;status&quot; is &quot;completed&quot;.
+     * Create a transcript from an audio or video file that is accessible via a URL.
      */
     public Transcript create(CreateTranscriptParameters request, boolean poll) {
         return transcriber.transcribe(request.getAudioUrl(), request, poll);

--- a/src/main/java/com/assemblyai/api/Transcriber.java
+++ b/src/main/java/com/assemblyai/api/Transcriber.java
@@ -3,6 +3,7 @@ package com.assemblyai.api;
 import com.assemblyai.api.core.Environment;
 import com.assemblyai.api.resources.transcript.requests.CreateTranscriptParameters;
 import com.assemblyai.api.types.CreateTranscriptOptionalParameters;
+import com.assemblyai.api.types.ICreateTranscriptOptionalParameters;
 import com.assemblyai.api.types.Transcript;
 import com.assemblyai.api.types.TranscriptStatus;
 import com.assemblyai.api.types.UploadedFile;
@@ -14,7 +15,7 @@ public final class Transcriber {
 
     private final AssemblyAI client;
 
-    private Transcriber(AssemblyAI client) {
+    Transcriber(AssemblyAI client) {
         this.client = client;
     }
 
@@ -37,7 +38,10 @@ public final class Transcriber {
     /**
      * Transcribes an audio file whose location can be specified via a URL.
      */
-    public Transcript transcribe(String url, CreateTranscriptOptionalParameters transcriptRequest, boolean poll) {
+    public Transcript transcribe(
+            String url,
+            ICreateTranscriptOptionalParameters transcriptRequest,
+            boolean poll) {
         CreateTranscriptParameters createTranscript = CreateTranscriptParameters.builder()
                 .audioUrl(url)
                 .languageCode(transcriptRequest.getLanguageCode())


### PR DESCRIPTION
In this PR, we introduce a `PollingTranscriptClient` that extends the fern-generated transcript client so that users can directly poll transcript creation.  This allows polling to occur without using the transcriber: 

```java
AssemblyAI aai = AssemblyAI.builder()
    .apiKey(System.getenv("ASSEMBLY_AI_API_KEY"))
    .build();

var transcript = aai.transcript().create(CreateTranscriptParameters.builder()
    .audioUrl("https://storage.googleapis.com/aai-docs-samples/nbc.mp3")
    .build(), true);

System.out.println("Created and polled transcript " + transcript);    
```