### PR TITLE
Add generic `getResponse` method for LeMUR

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,6 +1,7 @@
 # Specify files that shouldn't be modified by Fern
 src/main/java/com/assemblyai/api/AssemblyAI.java
 src/main/java/com/assemblyai/api/PollingTranscriptsClient.java
+src/main/java/com/assemblyai/api/EnhancedLemurClient.java
 src/main/java/com/assemblyai/api/Transcriber.java
 src/main/java/com/assemblyai/api/RealtimeTranscriber.java
 src/main/java/com/assemblyai/api/core/Constants.java

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'com.assemblyai'
             artifactId = 'assemblyai-java'
-            version = '1.2.0'
+            version = '2.0.0'
             from components.java
             pom {
                 scm {

--- a/sample-app/src/main/java/sample/App.java
+++ b/sample-app/src/main/java/sample/App.java
@@ -70,9 +70,9 @@ public final class App {
 
         System.out.println("Summary: " + response.getResponse());
 
-        LemurResponse response2 = client.lemur().getResponse(response.getRequestId());
+        LemurTaskResponse response2 = client.lemur().getResponse(response.getRequestId(), LemurTaskResponse.class);
 
-        System.out.println("Summary 2: " + ((LemurTaskResponse)response2.get()).getResponse());
+        System.out.println("Summary 2: " + response2.getResponse());
 
         transcript = client.transcripts().delete(transcript.getId());
         System.out.println("Delete transcript. " + transcript);

--- a/src/main/java/com/assemblyai/api/AssemblyAI.java
+++ b/src/main/java/com/assemblyai/api/AssemblyAI.java
@@ -20,14 +20,10 @@ public class AssemblyAI {
 
     protected final Supplier<RealtimeClient> realtimeClient;
 
-    protected final Supplier<LemurClient> lemurClient;
+    protected final Supplier<EnhancedLemurClient> lemurClient;
 
     public AssemblyAI(ClientOptions clientOptions) {
-        this.clientOptions = clientOptions;
-        this.filesClient = Suppliers.memoize(() -> new FilesClient(clientOptions));
-        this.transcriptClient = Suppliers.memoize(() -> new PollingTranscriptsClient(clientOptions, this));
-        this.realtimeClient = Suppliers.memoize(() -> new RealtimeClient(clientOptions));
-        this.lemurClient = Suppliers.memoize(() -> new LemurClient(clientOptions));
+        this(clientOptions, clientOptions);
     }
 
     public AssemblyAI(ClientOptions clientOptions, ClientOptions lemurClientOptions) {
@@ -35,7 +31,7 @@ public class AssemblyAI {
         this.filesClient = Suppliers.memoize(() -> new FilesClient(clientOptions));
         this.transcriptClient = Suppliers.memoize(() -> new PollingTranscriptsClient(clientOptions, this));
         this.realtimeClient = Suppliers.memoize(() -> new RealtimeClient(clientOptions));
-        this.lemurClient = Suppliers.memoize(() -> new LemurClient(lemurClientOptions));
+        this.lemurClient = Suppliers.memoize(() -> new EnhancedLemurClient(lemurClientOptions));
     }
 
     public FilesClient files() {
@@ -50,7 +46,7 @@ public class AssemblyAI {
         return this.realtimeClient.get();
     }
 
-    public LemurClient lemur() {
+    public EnhancedLemurClient lemur() {
         return this.lemurClient.get();
     }
 

--- a/src/main/java/com/assemblyai/api/EnhancedLemurClient.java
+++ b/src/main/java/com/assemblyai/api/EnhancedLemurClient.java
@@ -1,0 +1,58 @@
+package com.assemblyai.api;
+
+import com.assemblyai.api.core.ApiError;
+import com.assemblyai.api.core.ClientOptions;
+import com.assemblyai.api.core.ObjectMappers;
+import com.assemblyai.api.core.RequestOptions;
+import com.assemblyai.api.resources.lemur.LemurClient;
+import com.assemblyai.api.resources.lemur.types.ILemurBaseResponse;
+import okhttp3.*;
+
+import java.io.IOException;
+
+public final class EnhancedLemurClient extends LemurClient {
+    public EnhancedLemurClient(ClientOptions clientOptions) {
+        super(clientOptions);
+    }
+
+    /**
+     * Retrieve a LeMUR response that was previously generated.
+     */
+    public <T extends ILemurBaseResponse> T getResponse(String requestId, Class<T> responseType) {
+        return this.getResponse(requestId, responseType, null);
+    }
+
+    /**
+     * Retrieve a LeMUR response that was previously generated.
+     */
+    public <T extends ILemurBaseResponse> T getResponse(String requestId, Class<T> responseType, RequestOptions requestOptions) {
+        HttpUrl httpUrl = HttpUrl.parse(this.clientOptions.environment().getUrl())
+                .newBuilder()
+                .addPathSegments("lemur/v3")
+                .addPathSegment(requestId)
+                .build();
+        Request okhttpRequest = new Request.Builder()
+                .url(httpUrl)
+                .method("GET", null)
+                .headers(Headers.of(clientOptions.headers(requestOptions)))
+                .addHeader("Content-Type", "application/json")
+                .build();
+        try {
+            OkHttpClient client = clientOptions.httpClient();
+            if (requestOptions != null && requestOptions.getTimeout().isPresent()) {
+                client = clientOptions.httpClientWithTimeout(requestOptions);
+            }
+            Response response = client.newCall(okhttpRequest).execute();
+            ResponseBody responseBody = response.body();
+            if (response.isSuccessful()) {
+                return ObjectMappers.JSON_MAPPER.readValue(responseBody.string(), responseType);
+            }
+            throw new ApiError(
+                    response.code(),
+                    ObjectMappers.JSON_MAPPER.readValue(
+                            responseBody != null ? responseBody.string() : "{}", Object.class));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/assemblyai/api/core/Constants.java
+++ b/src/main/java/com/assemblyai/api/core/Constants.java
@@ -1,5 +1,5 @@
 package com.assemblyai.api.core;
 
 public class Constants {
-    public static final String SDK_VERSION = "1.1.3";
+    public static final String SDK_VERSION = "2.0.0";
 }


### PR DESCRIPTION
The `LemurTaskResponse`, `LemurActionItemsResponse`, and `LemurSummaryResponse` types are indistinguishable from each other, so the discriminator within the JSON deserializer cannot know which type to return and defaults to `LemurTaskResponse`.

To let the user chose which type should be used, a generic overload has been added.

Please give feedback on how this is handled, and the naming of `EnhancedLemurClient`.