### PR TITLE
feat(java): Remove conformer-2

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -5,9 +5,6 @@ src/main/java/com/assemblyai/api/Transcriber.java
 src/main/java/com/assemblyai/api/RealtimeTranscriber.java
 src/main/java/com/assemblyai/api/core/Constants.java
 
-# Ignore SpeechModel to manually mark conformer-2 as deprecated
-src/main/java/com/assemblyai/api/resources/transcripts/types/SpeechModel.java
-
 # Temporarily update deserialization logic
 src/main/java/com/assemblyai/api/core/ObjectMappers.java
 src/main/java/com/assemblyai/api/resources/realtime/types/FinalTranscript.java

--- a/src/main/java/com/assemblyai/api/resources/transcripts/types/SpeechModel.java
+++ b/src/main/java/com/assemblyai/api/resources/transcripts/types/SpeechModel.java
@@ -11,13 +11,6 @@ public final class SpeechModel {
 
     public static final SpeechModel BEST = new SpeechModel(Value.BEST, "best");
 
-    /**
-     * @deprecated The Conformer-2 option is deprecated and will stop working in the near future.
-     * Use {@link #BEST} or {@link #NANO} instead.
-     */
-    @Deprecated
-    public static final SpeechModel CONFORMER2 = new SpeechModel(Value.CONFORMER2, "conformer-2");
-
     private final Value value;
 
     private final String string;
@@ -53,8 +46,6 @@ public final class SpeechModel {
                 return visitor.visitNano();
             case BEST:
                 return visitor.visitBest();
-            case CONFORMER2:
-                return visitor.visitConformer2();
             case UNKNOWN:
             default:
                 return visitor.visitUnknown(string);
@@ -68,8 +59,6 @@ public final class SpeechModel {
                 return NANO;
             case "best":
                 return BEST;
-            case "conformer-2":
-                return CONFORMER2;
             default:
                 return new SpeechModel(Value.UNKNOWN, value);
         }
@@ -80,13 +69,6 @@ public final class SpeechModel {
 
         NANO,
 
-        /**
-         * @deprecated The Conformer-2 option is deprecated and will stop working in the near future.
-         * Use {@link #BEST} or {@link #NANO} instead.
-         */
-        @Deprecated
-        CONFORMER2,
-
         UNKNOWN
     }
 
@@ -94,8 +76,6 @@ public final class SpeechModel {
         T visitBest();
 
         T visitNano();
-
-        T visitConformer2();
 
         T visitUnknown(String unknownType);
     }


### PR DESCRIPTION
# **Remove conformer-2**

This would normally be a breaking change, but the API already stopped accepting `conformer-2` as an option, so it doesn't work anymore anyways.
This removes `conformer-2` from the speech model enum.