### PR TITLE
Map optional transcript params to transcript params using JSON

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'com.assemblyai'
             artifactId = 'assemblyai-java'
-            version = '2.3.0'
+            version = '2.3.1'
             from components.java
             pom {
                 scm {

--- a/sample-app/src/main/java/sample/App.java
+++ b/sample-app/src/main/java/sample/App.java
@@ -31,23 +31,12 @@ public final class App {
     public static void main(String... args) throws IOException, InterruptedException, ExecutionException {
         AssemblyAI client = AssemblyAI.builder()
                 .apiKey(System.getenv("ASSEMBLYAI_API_KEY"))
-                .environment(Environment.custom("http://localhost:10000"))
                 .build();
 
         Transcript transcript = client.transcripts().transcribe(
                 "https://storage.googleapis.com/aai-docs-samples/nbc.mp3",
                 TranscriptOptionalParams.builder()
                         .sentimentAnalysis(true)
-                        .languageDetection(true)
-                        .audioEndAt(1000)
-                        .audioStartFrom(10)
-                        .autoChapters(true)
-                        .autoHighlights(Optional.of(true))
-                        .boostParam(TranscriptBoostParam.HIGH)
-                        .customSpelling(List.of(TranscriptCustomSpelling.builder()
-                                .to("NBC")
-                                .addFrom("nbc")
-                                .build()))
                         .build()
         );
 

--- a/sample-app/src/main/java/sample/App.java
+++ b/sample-app/src/main/java/sample/App.java
@@ -5,7 +5,6 @@ import com.assemblyai.api.RealtimeTranscriber;
 import com.assemblyai.api.core.ApiError;
 import com.assemblyai.api.core.AssemblyAIApiException;
 import com.assemblyai.api.core.AssemblyAIException;
-import com.assemblyai.api.core.Environment;
 import com.assemblyai.api.resources.files.types.UploadedFile;
 import com.assemblyai.api.resources.lemur.requests.LemurQuestionAnswerParams;
 import com.assemblyai.api.resources.lemur.requests.LemurTaskParams;
@@ -22,7 +21,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 

--- a/sample-app/src/main/java/sample/App.java
+++ b/sample-app/src/main/java/sample/App.java
@@ -5,6 +5,7 @@ import com.assemblyai.api.RealtimeTranscriber;
 import com.assemblyai.api.core.ApiError;
 import com.assemblyai.api.core.AssemblyAIApiException;
 import com.assemblyai.api.core.AssemblyAIException;
+import com.assemblyai.api.core.Environment;
 import com.assemblyai.api.resources.files.types.UploadedFile;
 import com.assemblyai.api.resources.lemur.requests.LemurQuestionAnswerParams;
 import com.assemblyai.api.resources.lemur.requests.LemurTaskParams;
@@ -21,6 +22,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -29,12 +31,23 @@ public final class App {
     public static void main(String... args) throws IOException, InterruptedException, ExecutionException {
         AssemblyAI client = AssemblyAI.builder()
                 .apiKey(System.getenv("ASSEMBLYAI_API_KEY"))
+                .environment(Environment.custom("http://localhost:10000"))
                 .build();
 
         Transcript transcript = client.transcripts().transcribe(
                 "https://storage.googleapis.com/aai-docs-samples/nbc.mp3",
                 TranscriptOptionalParams.builder()
                         .sentimentAnalysis(true)
+                        .languageDetection(true)
+                        .audioEndAt(1000)
+                        .audioStartFrom(10)
+                        .autoChapters(true)
+                        .autoHighlights(Optional.of(true))
+                        .boostParam(TranscriptBoostParam.HIGH)
+                        .customSpelling(List.of(TranscriptCustomSpelling.builder()
+                                .to("NBC")
+                                .addFrom("nbc")
+                                .build()))
                         .build()
         );
 

--- a/src/main/java/com/assemblyai/api/PollingTranscriptsClient.java
+++ b/src/main/java/com/assemblyai/api/PollingTranscriptsClient.java
@@ -1,15 +1,15 @@
 package com.assemblyai.api;
 
 import com.assemblyai.api.core.ClientOptions;
+import com.assemblyai.api.core.ObjectMappers;
 import com.assemblyai.api.core.RequestOptions;
 import com.assemblyai.api.resources.files.types.UploadedFile;
 import com.assemblyai.api.resources.transcripts.TranscriptsClient;
 import com.assemblyai.api.resources.transcripts.requests.TranscriptParams;
 import com.assemblyai.api.resources.transcripts.requests.WordSearchParams;
-import com.assemblyai.api.resources.transcripts.types.Transcript;
-import com.assemblyai.api.resources.transcripts.types.TranscriptOptionalParams;
-import com.assemblyai.api.resources.transcripts.types.TranscriptStatus;
-import com.assemblyai.api.resources.transcripts.types.WordSearchResponse;
+import com.assemblyai.api.resources.transcripts.types.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.File;
 import java.io.IOException;
@@ -105,45 +105,16 @@ public class PollingTranscriptsClient extends TranscriptsClient {
      * @return Queued transcript
      */
     public Transcript submit(String url, TranscriptOptionalParams transcriptParams) {
-        TranscriptParams createTranscriptParams = TranscriptParams.builder()
-                .audioUrl(url)
-                .languageCode(transcriptParams.getLanguageCode())
-                .punctuate(transcriptParams.getPunctuate())
-                .formatText(transcriptParams.getFormatText())
-                .dualChannel(transcriptParams.getDualChannel())
-                .webhookUrl(transcriptParams.getWebhookUrl())
-                .webhookAuthHeaderName(transcriptParams.getWebhookAuthHeaderName())
-                .webhookAuthHeaderValue(transcriptParams.getWebhookAuthHeaderValue())
-                .autoHighlights(transcriptParams.getAutoHighlights())
-                .audioStartFrom(transcriptParams.getAudioStartFrom())
-                .audioEndAt(transcriptParams.getAudioEndAt())
-                .wordBoost(transcriptParams.getWordBoost())
-                .boostParam(transcriptParams.getBoostParam())
-                .filterProfanity(transcriptParams.getFilterProfanity())
-                .redactPii(transcriptParams.getRedactPii())
-                .redactPiiAudio(transcriptParams.getRedactPiiAudio())
-                .redactPiiAudioQuality(transcriptParams.getRedactPiiAudioQuality())
-                .redactPiiPolicies(transcriptParams.getRedactPiiPolicies())
-                .redactPiiSub(transcriptParams.getRedactPiiSub())
-                .speakerLabels(transcriptParams.getSpeakerLabels())
-                .speakersExpected(transcriptParams.getSpeakersExpected())
-                .contentSafety(transcriptParams.getContentSafety())
-                .iabCategories(transcriptParams.getIabCategories())
-                .languageDetection(transcriptParams.getLanguageDetection())
-                .customSpelling(transcriptParams.getCustomSpelling())
-                .disfluencies(transcriptParams.getDisfluencies())
-                .sentimentAnalysis(transcriptParams.getSentimentAnalysis())
-                .autoChapters(transcriptParams.getAutoChapters())
-                .entityDetection(transcriptParams.getEntityDetection())
-                .speechModel(transcriptParams.getSpeechModel())
-                .speechThreshold(transcriptParams.getSpeechThreshold())
-                .summarization(transcriptParams.getSummarization())
-                .summaryModel(transcriptParams.getSummaryModel())
-                .summaryType(transcriptParams.getSummaryType())
-                .customTopics(transcriptParams.getCustomTopics())
-                .topics(transcriptParams.getTopics())
-                .build();
-        return super.submit(createTranscriptParams);
+        ObjectNode transcriptParamsJson = ObjectMappers.JSON_MAPPER.valueToTree(transcriptParams);
+        transcriptParamsJson.put("audio_url", url);
+        TranscriptParams fullTranscriptParams;
+        try {
+            fullTranscriptParams = ObjectMappers.JSON_MAPPER.treeToValue(transcriptParamsJson, TranscriptParams.class);
+        } catch (JsonProcessingException e) {
+            // this should never happen
+            throw new RuntimeException(e);
+        }
+        return super.submit(fullTranscriptParams);
     }
 
     /**

--- a/src/main/java/com/assemblyai/api/core/Constants.java
+++ b/src/main/java/com/assemblyai/api/core/Constants.java
@@ -1,5 +1,5 @@
 package com.assemblyai.api.core;
 
 public class Constants {
-    public static final String SDK_VERSION = "2.3.0";
+    public static final String SDK_VERSION = "2.3.1";
 }


### PR DESCRIPTION
The mapping of optional transcript params to transcript params was manual and not maintainable.
This PR converts the optional params to JSON, sets the audio_url, and then deserializes it to transcript params.
This is not the most performant solution, as handwriting would be, and using a mapper would be second fastest at the cost of an additional dependency.
But this is a better solution for now as we won't accidentally not copy new parameters if we don't maintain the manual mapping code.