### PR TITLE
Update README.md with Android ProGuard configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,8 @@ The default timeout should be sufficient for most use cases.
 However, depending on your network speed and distance, you may occasionally experience timeouts, in which case you can increase the timeout.
 
 ## Android
-### Proguard configuration
 
-Keep AssemblyAI SDK classes from being obfuscated. This is required for proper SDK functionality when using code shrinking (isMinifyEnabled = true)
+If you've enabled [Code shrinking](https://developer.android.com/build/shrink-code#shrink-code) using `minifyEnabled`, you need to add the following ProGuard configuration to keep R8 from incorrectly marking the SDK classes as unused.
 ```text
 -keep class com.assemblyai.api.** { *; }
 ```

--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ For this operation, the call timeout will be 30 seconds, and the other timeouts 
 The default timeout should be sufficient for most use cases. 
 However, depending on your network speed and distance, you may occasionally experience timeouts, in which case you can increase the timeout.
 
+## Android
+### Proguard configuration
+
+Keep AssemblyAI SDK classes from being obfuscated. This is required for proper SDK functionality when using code shrinking (isMinifyEnabled = true)
+```text
+-keep class com.assemblyai.api.** { *; }
+```
+
 ## Contributing
 While we value open-source contributions to this SDK, this library
 is generated programmatically. Additions made directly to this library


### PR DESCRIPTION
Add Android ProGuard configuration for AssemblyAI SDK

Add necessary ProGuard keep rules to README.md to ensure proper  functionality of the AssemblyAI SDK when code shrinking is enabled  in Android release builds.

This documentation helps developers avoid potential runtime issues  when using the SDK with minification enabled.